### PR TITLE
Accept custom levels

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
@@ -98,7 +98,7 @@ inline DiagnosticLevel valToLevel(const int val)
     return Level_Stale;
   }
 
-  RCLCPP_ERROR(
+  RCLCPP_DEBUG(
     rclcpp::get_logger(
       "generic_analyzer_base"),
     R"(Attempting to convert %d into DiagnosticLevel.


### PR DESCRIPTION
For the VCU integration we need to not bloat the logs with errors when receiving custom diagnostics levels.
Do you think this is something we can accept in our codebase as well? If not, vcu+agbot will simply use this branch from now on.